### PR TITLE
Move :bucket out of :s3_credentials. Having it there causes errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ This way if your Paperclip default_url for a missing image kicks in, it will cor
 
 config.paperclip_defaults = {
   :storage => :s3,
+  :bucket => ENV["s3_bucket"],
   :s3_credentials => {
-    :bucket => ENV["s3_bucket"],
     :access_key_id => ENV["s3_access_key_id"],
     :secret_access_key => ENV["s3_secret_access_key"]
   }


### PR DESCRIPTION
When the bucket is inside the s3_credentials it causes errors (only for the destroy action, for some reason). When it's moved out the errors go away.